### PR TITLE
civ enhancements & cleanups

### DIFF
--- a/node_modules/grad-civs/functions/init/fn_initModule.sqf
+++ b/node_modules/grad-civs/functions/init/fn_initModule.sqf
@@ -1,6 +1,11 @@
 #include "..\..\component.hpp"
 
-INFO("running full grad-civs initialization now!");
+if (!(isNil "GRAD_CIVS_INITIALIZED")) exitWith {
+    WARNING("grad-civs already initialized (autoInit maybe?), will NOT run again. If you're sure about this, unset GRAD_CIVS_INITIALIZED and try again!");
+};
+GRAD_CIVS_INITIALIZED = true;
+
+INFO("running full grad-civs initialization now...");
 
 [] call grad_civs_fnc_initConfig;
 [] call grad_civs_fnc_initServer;

--- a/node_modules/grad-civs/functions/sm_business/fn_sm_business_state_voyage_loop.sqf
+++ b/node_modules/grad-civs/functions/sm_business/fn_sm_business_state_voyage_loop.sqf
@@ -1,3 +1,5 @@
 private _wpidx = currentWaypoint group _this;
-private _wppos = waypointPosition ((waypoints (group _this)) select _wpidx);
+private _wps = waypoints (group _this);
+private _wppos = waypointPosition (_wps select _wpidx);
+
 [_this,  format ["traveling to waypoint %1, %2 (%3m left)", _wpidx, _wppos, _this distance _wppos]] call grad_civs_fnc_setCurrentlyThinking;

--- a/node_modules/grad-civs/functions/sm_lifecycle/fn_sm_lifecycle_trans_life_despawn_condition.sqf
+++ b/node_modules/grad-civs/functions/sm_lifecycle/fn_sm_lifecycle_trans_life_despawn_condition.sqf
@@ -17,6 +17,7 @@ if (_this distance nearestBuilding _this < 3) then {
 private _playersAreClose = true isEqualTo ({
     if (_this distance _x < _cleanupDistance) exitWith { true };
     false
-} count ([] call CBA_fnc_players));
+} count (allPlayers - (entities "HeadlessClient_F")));
+// CBA_fnc_players would work, if you dont mind things despawning close to zeus
 
 !_playersAreClose

--- a/node_modules/grad-civs/functions/spawn/fn_addFootsy.sqf
+++ b/node_modules/grad-civs/functions/spawn/fn_addFootsy.sqf
@@ -10,7 +10,7 @@ _pos = [
     GRAD_CIVS_SPAWNDISTANCEONFOOTMIN,
     GRAD_CIVS_SPAWNDISTANCEONFOOTMAX,
     ["patrol"] call grad_civs_fnc_getGlobalCivs
-] call grad_civs_fnc_findSpawnPosition;
+] call grad_civs_fnc_findResidentSpawnHouse;
 LOGTIME_END("findSpawnPos_onFoot");
 
 if (_pos isEqualTo [0,0,0]) exitWith {};
@@ -19,4 +19,6 @@ private _groupSize = floor random GRAD_CIVS_INITIALGROUPSIZE;
 
 LOGTIME_START("spawnCiv_onFoot");
 _group = [_pos, _groupSize, objNull, "patrol"] call grad_civs_fnc_spawnCivilianGroup;
+_house setVariable ["grad_civs_residents", units _group, true];
+
 LOGTIME_END("spawnCiv_onFoot");

--- a/node_modules/grad-civs/functions/spawn/fn_spawnPass.sqf
+++ b/node_modules/grad-civs/functions/spawn/fn_spawnPass.sqf
@@ -1,6 +1,6 @@
 #include "..\..\component.hpp"
 
-_allPlayers = (call CBA_fnc_players);
+_allPlayers = allPlayers - (entities "HeadlessClient_F");
 if (count _allPlayers == 0) exitWith {};
 
 private _fps = diag_fps;


### PR DESCRIPTION
* ensure Zeus triggers civilians, making for easier debugging
* prevent module re-init, and errors associated with it
* patrols spawn near houses only, and count as occupants (!). jungles and deserts were a bit too busy.